### PR TITLE
update prompt for multiline input

### DIFF
--- a/gptcli.py
+++ b/gptcli.py
@@ -103,7 +103,7 @@ def setup_readline():
 
 def read_multiline() -> str:
     contents = []
-    c.print("Input multiline data, cancel with ctrl-c:")
+    c.print("Input multiline data, finish input with ctrl-d(Linux/macOS) or ctrl-z(Windows), cancel with ctrl-c:")
     while True:
         try:
             line = input()


### PR DESCRIPTION
我在windows和ubuntu server上观察的完成多行输入和取消多行输入的快捷键貌似是这样的.
```
Input multiline data, finish input with ctrl-d(Linux/macOS) or ctrl-z(Windows), cancel with ctrl-c:
```